### PR TITLE
require CMake 2.8.8

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@
 
 #This is an CMake configuration file for FluoRender
 
-cmake_minimum_required ( VERSION 2.6 )
+cmake_minimum_required ( VERSION 2.8.8 )
 
 #for MSVC builds
 if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")


### PR DESCRIPTION
According to http://www.cmake.org/Wiki/CMake/Tutorials/Object_Library,
the `add_library(myObjects OBJECT a.c b.c)` form (with `OBJECT` as the
second argument to `add_library()`) was added to CMake in version 2.8.8.
