### PR TITLE
Added Linux support (preliminary)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,54 +1,55 @@
-#/*
-#For more information, please see: http://software.sci.utah.edu
-#
-#The MIT License
-#
-#Copyright (c) 2014 Scientific Computing and Imaging Institute,
-#University of Utah.
-#
-#
-#Permission is hereby granted, free of charge, to any person obtaining a
-#copy of this software and associated documentation files (the "Software"),
-#to deal in the Software without restriction, including without limitation
-#the rights to use, copy, modify, merge, publish, distribute, sublicense,
-#and/or sell copies of the Software, and to permit persons to whom the
-#Software is furnished to do so, subject to the following conditions:
-#
-#The above copyright notice and this permission notice shall be included
-#in all copies or substantial portions of the Software.
-#
-#THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
-#OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-#FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
-#THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-#LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-#FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-#DEALINGS IN THE SOFTWARE.
-#*/
+# /*
+# For more information, please see: http://software.sci.utah.edu
+# 
+# The MIT License
+# 
+# Copyright (c) 2014 Scientific Computing and Imaging Institute,
+# University of Utah.
+# 
+# 
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+# 
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
+# */
 
-#This is an CMake configuration file for FluoRender
+# This is an CMake configuration file for FluoRender
 
-cmake_minimum_required ( VERSION 2.8.8 )
+cmake_minimum_required(VERSION 2.8.8)
 
-#for MSVC builds
-if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
+# for MSVC builds
+if(WIN32)
   if(MSVC)
     SET(MSVC_INCREMENTAL_DEFAULT OFF)
   endif()
 endif()
 
-project ( FluoRender )
+project(FluoRender)
 
 IF((COMMAND cmake_policy) AND NOT (CMAKE_MAJOR_VERSION LESS 3))
   CMAKE_POLICY(SET CMP0040 NEW)
   CMAKE_POLICY(SET CMP0043 NEW)
 ENDIF()
 
-if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-  # Mac OS X
+set(CMAKE_VERBOSE_MAKEFILE ON)
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/")
+
+if(UNIX OR APPLE OR MINGW)
   set(ARCHITECTURE 64)
-else()
-  # Windows
+elseif(WIN32)
   if(${CMAKE_SIZEOF_VOID_P} MATCHES "8")
     set(ARCHITECTURE 64)
   else()
@@ -62,38 +63,44 @@ else()
   add_definitions(-DFLUORENDER_ARCH="32bit")
 endif()
 
+set(RELEASE_FLAGS ${RELEASE_FLAGS} -O3 -march=corei7-avx)
+set(DEBUG_FLAGS ${DEBUG_FLAGS} -O0 -march=corei7-avx -ggdb)
+
 add_definitions(-DFLUORENDER_TITLE="FluoRender")
 
-add_definitions(-DVERSION_MAJOR=2)                   #Be sure to update the Versions and Date for each release!!!!
-add_definitions(-DVERSION_MINOR=20.1)                  #
-add_definitions(-DVERSION_MAJOR_TAG="2")             #
-add_definitions(-DVERSION_MINOR_TAG="20.1")            #
-add_definitions(-DVERSION_COPYRIGHT="December 2016")  # Up to here!
+add_definitions(-DVERSION_MAJOR=2)                   # Be sure to update the Versions and Date for each release!!!!
+add_definitions(-DVERSION_MINOR=20.1)                # 
+add_definitions(-DVERSION_MAJOR_TAG="2")             # 
+add_definitions(-DVERSION_MINOR_TAG="20.1")          # 
+add_definitions(-DVERSION_COPYRIGHT="December 2016") # Up to here!
 
-#static compile
+# static compile
 add_definitions(-DSTATIC_COMPILE)
 
-#teem required definitions
+# teem required definitions
 add_definitions(-DTEEM_DIO=0)
 add_definitions(-DTEEM_ENDIAN=1234)
 add_definitions(-DTEEM_QNANHIBIT=1)
 
-#output directories
+# output directories
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BUILD_DIR})
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BUILD_DIR})
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
-#wxWidgets
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# wxWidgets
 set(wxWidgets_USE_REL_AND_DBG ON)
 if(${CMAKE_BUILD_TYPE} MATCHES "Release")
   set(wxWidgets_CONFIGURATION mswu)
 elseif(${CMAKE_BUILD_TYPE} MATCHES "Debug")
   set(wxWidgets_CONFIGURATION mswud)
 endif()
-find_package(wxWidgets COMPONENTS core base aui html xml adv gl stc scintilla REQUIRED)
+find_package(wxWidgets COMPONENTS core base aui html xml adv gl stc REQUIRED)
 include(${wxWidgets_USE_FILE})
 set(wxWidgets_USE_STATIC ON)
-if (APPLE)
+if(UNIX OR APPLE OR MINGW)
   find_package(TIFF REQUIRED)
   include_directories(${TIFF_INCLUDE_DIR})
 else()
@@ -101,34 +108,40 @@ else()
 endif()
 add_definitions(-DUNICODE)
 add_definitions(-D_UNICODE)
-#solution for wxWidgets linking "ambiguous" errors
+# solution for wxWidgets linking "ambiguous" errors
 add_definitions(-D_WCHAR_H_CPLUSPLUS_98_CONFORMANCE_)
-#fix the library names for OSX if needed.
-if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+# fix the library names for OSX if needed.
+if(APPLE)
   foreach(arg ${wxWidgets_LIBRARIES})
     set(wxlib_out "${wxlib_out} ${arg}")
   endforeach()
   string(STRIP ${wxlib_out} wxWidgets_LIBRARIES)
-  string(REGEX REPLACE "libwx_osx_cocoau_scintilla" "libwxscintilla"
+  string(REGEX REPLACE "wx_osx_cocoau_scintilla" "wxscintilla"
     wxWidgets_LIBRARIES ${wxWidgets_LIBRARIES})
-  find_package(Freetype REQUIRED)
-  include_directories(${FREETYPE_INCLUDE_DIRS})
+elseif(UNIX OR MINGW)
+  foreach(arg ${wxWidgets_LIBRARIES})
+    set(wxlib_out "${wxlib_out} ${arg}")
+  endforeach()
+  string(STRIP ${wxlib_out} wxWidgets_LIBRARIES)
+  string(REGEX REPLACE "wx_gtk3u_scintilla" "wxscintilla"
+    wxWidgets_LIBRARIES ${wxWidgets_LIBRARIES})
 endif()
 
-#OpenGL
+# OpenGL
 find_package(OpenGL REQUIRED)
 
-#Boost
-set(Boost_USE_STATIC_LIBS        ON) # only find static libs
+# Boost
+# only find static libs:
+#set(Boost_USE_STATIC_LIBS        ON)
 set(Boost_USE_MULTITHREADED      ON)
 set(Boost_USE_STATIC_RUNTIME    OFF)
 find_package(Boost COMPONENTS system chrono filesystem REQUIRED)
 include_directories(${Boost_INCLUDE_DIR})
 
-#teem
+# teem
 # add zlib
 find_package(ZLIB)
-if (ZLIB_FOUND)
+if(ZLIB_FOUND)
   add_definitions(-DTEEM_ZLIB=1)
   include_directories(${ZLIB_INCLUDE_DIRS})
 endif()
@@ -150,7 +163,7 @@ add_library(TEEM_OBJ OBJECT
   ${airsrc} ${hestsrc} ${nrrdsrc} ${biffsrc}
   ${airhdr} ${hesthdr} ${nrrdhdr} ${biffhdr})
 
-#glew
+# glew
 include_directories(${FluoRender_SOURCE_DIR}/fluorender/glew)
 include_directories(${FluoRender_SOURCE_DIR}/fluorender/glew/GL)
 file(GLOB gl_srcs fluorender/glew/*.c)
@@ -159,140 +172,145 @@ file(GLOB gl_hdrs2 fluorender/glew/GL/*.h)
 add_library(GLEW_OBJ OBJECT
   ${gl_srcs} ${gl_hdrs1} ${gl_hdrs2})
 
-#pole
+# pole
 include_directories(${FluoRender_SOURCE_DIR}/fluorender/pole)
 file(GLOB pole_srcs fluorender/pole/pole.cpp)
 file(GLOB pole_hdrs fluorender/pole/pole.h)
 add_library(POLE_OBJ OBJECT ${pole_srcs} ${pole_hdrs})
 
-#ffmpeg
-if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
+# ffmpeg
+if(WIN32)
   include_directories(${FluoRender_SOURCE_DIR}/fluorender/ffmpeg/include)
-  file(GLOB ffmpeg_LIBRARIES ${FluoRender_SOURCE_DIR}/fluorender/ffmpeg/lib/Win64/*.a ${FluoRender_SOURCE_DIR}/fluorender/ffmpeg/lib/Win64/*.lib)
+  file(GLOB FFMPEG_LIBRARIES ${FluoRender_SOURCE_DIR}/fluorender/ffmpeg/lib/Win64/*.a ${FluoRender_SOURCE_DIR}/fluorender/ffmpeg/lib/Win64/*.lib)
   add_definitions(-D__STDC_CONSTANT_MACROS)
-else()
+elseif(APPLE)
   include_directories(${FluoRender_SOURCE_DIR}/fluorender/ffmpeg/include)
-  file(GLOB ffmpeg_LIBRARIES ${FluoRender_SOURCE_DIR}/fluorender/ffmpeg/lib/OSX/*.a)
+  file(GLOB FFMPEG_LIBRARIES ${FluoRender_SOURCE_DIR}/fluorender/ffmpeg/lib/OSX/*.a)
+else()
+  find_package(FFMPEG REQUIRED)
+  #string(REPLACE "/usr/include/" "" FFMPEG_INCLUDE_DIR "${FFMPEG_INCLUDE_DIR}")
+  #include_directories(${FFMPEG_INCLUDE_DIR})
 endif()
 
-#FluoRender
+# FluoRender
 include_directories(${FluoRender_SOURCE_DIR}/fluorender)
 include_directories(${FluoRender_SOURCE_DIR}/fluorender/FluoRender)
 
-#Formats
+# Formats
 include_directories(${FluoRender_SOURCE_DIR}/fluorender/FluoRender/Formats)
 file(GLOB fmt_src fluorender/FluoRender/Formats/*.cpp)
 file(GLOB fmt_hdr fluorender/FluoRender/Formats/*.h)
 add_library(FORMATS_OBJ OBJECT
   ${fmt_src} ${fmt_hdr})
 
-#Video
+# Video
 include_directories(${FluoRender_SOURCE_DIR}/fluorender/FluoRender/Video)
 file(GLOB vid_src fluorender/FluoRender/Video/*.cpp)
 file(GLOB vid_hdr fluorender/FluoRender/Video/*.h)
 add_library(VIDEO_OBJ OBJECT
   ${vid_src} ${vid_hdr})
 
-#Tracking
+# Tracking
 include_directories(${FluoRender_SOURCE_DIR}/fluorender/FluoRender/Tracking)
 file(GLOB trk_src fluorender/FluoRender/Tracking/*.cpp)
 file(GLOB trk_hdr fluorender/FluoRender/Tracking/*.h)
 add_library(TRACKING_OBJ OBJECT
   ${trk_src} ${trk_hdr})
 
-#Components
+# Components
 include_directories(${FluoRender_SOURCE_DIR}/fluorender/FluoRender/Components)
 file(GLOB cmp_src fluorender/FluoRender/Components/*.cpp)
 file(GLOB cmp_hdr fluorender/FluoRender/Components/*.h)
 add_library(COMPONENTS_OBJ OBJECT
   ${cmp_src} ${cmp_hdr})
 
-#Cluster
+# Cluster
 include_directories(${FluoRender_SOURCE_DIR}/fluorender/FluoRender/Cluster)
 file(GLOB clstr_src fluorender/FluoRender/Cluster/*.cpp)
 file(GLOB clstr_hdr fluorender/FluoRender/Cluster/*.h)
 add_library(CLUSTER_OBJ OBJECT
   ${clstr_src} ${clstr_hdr})
 
-#Calculate
+# Calculate
 include_directories(${FluoRender_SOURCE_DIR}/fluorender/FluoRender/Calculate)
 file(GLOB calc_src fluorender/FluoRender/Calculate/*.cpp)
 file(GLOB calc_hdr fluorender/FluoRender/Calculate/*.h)
 add_library(CALCULATE_OBJ OBJECT
   ${calc_src} ${calc_hdr})
 
-#Animators
+# Animators
 include_directories(${FluoRender_SOURCE_DIR}/fluorender/FluoRender/Animators)
 file(GLOB ani_src fluorender/FluoRender/Animator/*.cpp)
 file(GLOB ani_hdr fluorender/FluoRender/Animator/*.h)
 add_library(ANIMATORS_OBJ OBJECT
   ${ani_src} ${ani_hdr})
 
-#NV
+# NV
 include_directories(${FluoRender_SOURCE_DIR}/fluorender/FluoRender/NV)
 file(GLOB nv_src fluorender/FluoRender/NV/*.cpp)
 file(GLOB nv_hdr fluorender/FluoRender/NV/*.h)
 add_library(NV_OBJ OBJECT
   ${nv_src} ${nv_hdr})
 
-#FLIVR
+# FLIVR
 include_directories(${FluoRender_SOURCE_DIR}/fluorender/FluoRender/FLIVR)
 file(GLOB fli_src fluorender/FluoRender/FLIVR/*.cpp)
 file(GLOB fli_hdr fluorender/FluoRender/FLIVR/*.h)
 add_library(FLIVR_OBJ OBJECT
   ${fli_src} ${fli_hdr})
 
-#Converters
+# Converters
 include_directories(${FluoRender_SOURCE_DIR}/fluorender/FluoRender/Converters)
 file(GLOB cvt_src fluorender/FluoRender/Converters/*.cpp)
 file(GLOB cvt_hdr fluorender/FluoRender/Converters/*.h)
 add_library(CONVERTERS_OBJ OBJECT
   ${cvt_src} ${cvt_hdr})
 
-#images
+# images
 include_directories(${FluoRender_SOURCE_DIR}/fluorender/FluoRender/img)
 file(GLOB pngs_hdr fluorender/FluoRender/img/*.h)
 file(GLOB pngs_src fluorender/FluoRender/img/*.cpp)
 add_library(IMAGES_OBJ OBJECT  ${pngs_hdr} ${pngs_src})
 
-#OpenCL
-if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
+# OpenCL
+if(WIN32)
   include_directories(${FluoRender_SOURCE_DIR}/fluorender/OpenCL/include)
   if(${ARCHITECTURE} MATCHES 64)
-    file(GLOB OPENCL_LIBRARIES ${FluoRender_SOURCE_DIR}/fluorender/OpenCL/lib/x86_64/*.lib)
+    file(GLOB OpenCL_LIBRARIES ${FluoRender_SOURCE_DIR}/fluorender/OpenCL/lib/x86_64/*.lib)
   elseif(${ARCHITECTURE} MATCHES 32)
-    file(GLOB OPENCL_LIBRARIES ${FluoRender_SOURCE_DIR}/fluorender/OpenCL/lib/x86/*.lib)
+    file(GLOB OpenCL_LIBRARIES ${FluoRender_SOURCE_DIR}/fluorender/OpenCL/lib/x86/*.lib)
   endif()
-elseif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-  include(${CMAKE_SOURCE_DIR}/FindOpenCL.cmake)
-  include_directories( ${OPENCL_INCLUDE_DIRS})
+elseif(UNIX OR APPLE OR MINGW)
+  #include(${CMAKE_SOURCE_DIR}/FindOpenCL.cmake)
+  find_package(OpenCL REQUIRED)
+  include_directories(${OpenCL_INCLUDE_DIRS})
 endif()
 
-#freetype
+# freetype
 include_directories(${FluoRender_SOURCE_DIR}/fluorender/freetype/include)
-if (WIN32)
+if(WIN32)
   file(GLOB FREETYPE_LIBRARIES ${FluoRender_SOURCE_DIR}/fluorender/freetype/lib/*.lib)
 else()
   find_package(Freetype REQUIRED)
   include_directories(${FREETYPE_INCLUDE_DIRS})
 endif()
 
-#other sources
+# other sources
 file(GLOB src fluorender/FluoRender/*.cpp)
 file(GLOB hdr fluorender/FluoRender/*.h)
 file(GLOB rsc fluorender/FluoRender/img/*.xpm)
 
-#SynthBB
+# SynthBB
 include_directories(${FluoRender_SOURCE_DIR}/fluorender/SynthBB)
 file(GLOB synthbb_hdr fluorender/SynthBB/*.h)
 file(GLOB synthbb_src fluorender/SynthBB/*.cpp)
 
-#MaskInt
+# MaskInt
 include_directories(${FluoRender_SOURCE_DIR}/fluorender/MaskInt)
 file(GLOB maskint_hdr fluorender/MaskInt/*.h)
 file(GLOB maskint_src fluorender/MaskInt/*.cpp)
 
-#ReadGMM
+# ReadGMM
 include_directories(${FluoRender_SOURCE_DIR}/fluorender/ReadGMM)
 file(GLOB readgmm_hdr fluorender/ReadGMM/*.h)
 file(GLOB readgmm_src fluorender/ReadGMM/*.cpp)
@@ -310,10 +328,10 @@ ELSEIF(WIN32)
   SET(icns "${CMAKE_CURRENT_SOURCE_DIR}/fluorender/FluoRender/img/fluorenderIcon.ico")
   ADD_DEFINITIONS(-DICON_RC_FILE="${icns}")
   SET(src ${src} ${icon_rc})
-ENDIF(APPLE)
+ENDIF()
 
-#platform specific rules
-if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+# platform specific rules
+if(APPLE)
   # Mac OS X
   if(NOT OPEN_GL_HEADER_LOC)
     add_definitions(-DOPEN_GL_HEADER_LOC=<OpenGL/gl.h>)
@@ -363,9 +381,58 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     $<TARGET_OBJECTS:TRACKING_OBJ>
     $<TARGET_OBJECTS:POLE_OBJ>
     $<TARGET_OBJECTS:TEEM_OBJ>)
-
-elseif(NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-  #Windows
+elseif(UNIX OR MINGW)
+  # Linux
+  #if(NOT OPEN_GL_HEADER_LOC)
+  #  add_definitions(-DOPEN_GL_HEADER_LOC=<OpenGL/gl.h>)
+  #endif()
+  #if(NOT OPEN_GLU_HEADER_LOC)
+  #  add_definitions(-DOPEN_GLU_HEADER_LOC=<OpenGL/glu.h>)
+  #endif()
+  #add_definitions(-D_DARWIN)
+  set(CFLAGS "-fPIC")
+  set(CXXFLAGS "-fPIC ")
+  #include(BundleUtilities)
+  add_executable(FluoRender
+    ${src} ${hdr} ${rsc} ${icns}
+    $<TARGET_OBJECTS:IMAGES_OBJ>
+    $<TARGET_OBJECTS:CONVERTERS_OBJ>
+    $<TARGET_OBJECTS:FLIVR_OBJ>
+    $<TARGET_OBJECTS:ANIMATORS_OBJ>
+    $<TARGET_OBJECTS:NV_OBJ>
+    $<TARGET_OBJECTS:FORMATS_OBJ>
+    $<TARGET_OBJECTS:VIDEO_OBJ>
+    $<TARGET_OBJECTS:TRACKING_OBJ>
+    $<TARGET_OBJECTS:COMPONENTS_OBJ>
+    $<TARGET_OBJECTS:CLUSTER_OBJ>
+    $<TARGET_OBJECTS:CALCULATE_OBJ>
+    $<TARGET_OBJECTS:GLEW_OBJ>
+    $<TARGET_OBJECTS:POLE_OBJ>
+    $<TARGET_OBJECTS:TEEM_OBJ>)
+  add_executable(SynthBB
+    ${synthbb_src} ${synthbb_hdr}
+    $<TARGET_OBJECTS:FLIVR_OBJ>
+    $<TARGET_OBJECTS:FORMATS_OBJ>
+    $<TARGET_OBJECTS:TRACKING_OBJ>
+    $<TARGET_OBJECTS:COMPONENTS_OBJ>
+    $<TARGET_OBJECTS:CLUSTER_OBJ>
+    $<TARGET_OBJECTS:GLEW_OBJ>
+    $<TARGET_OBJECTS:POLE_OBJ>
+    $<TARGET_OBJECTS:TEEM_OBJ>)
+  add_executable(MaskInt
+    ${maskint_src} ${maskint_hdr}
+    $<TARGET_OBJECTS:FORMATS_OBJ>
+    $<TARGET_OBJECTS:POLE_OBJ>
+    $<TARGET_OBJECTS:TEEM_OBJ>)
+  add_executable(ReadGMM
+    ${readgmm_src} ${readgmm_hdr}
+    $<TARGET_OBJECTS:FORMATS_OBJ>
+    $<TARGET_OBJECTS:CLUSTER_OBJ>
+    $<TARGET_OBJECTS:TRACKING_OBJ>
+    $<TARGET_OBJECTS:POLE_OBJ>
+    $<TARGET_OBJECTS:TEEM_OBJ>)
+elseif(WIN32)
+  # Windows
   if(NOT OPEN_GL_HEADER_LOC)
     add_definitions(-DOPEN_GL_HEADER_LOC=<GL/gl.h>)
   endif()
@@ -373,7 +440,7 @@ elseif(NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     add_definitions(-DOPEN_GLU_HEADER_LOC=<GL/glu.h>)
   endif()
   # windows
-  if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
+  if(WIN32)
     add_definitions(-DWIN32)
     add_definitions(-D_WIN32)
     if(MSVC)
@@ -385,16 +452,16 @@ elseif(NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
       add_definitions(-D_XKEYCHECK_H)
       set(CFLAGS "")
       set(CXXFLAGS "/EHsc")
-      #make sure the reference option is turned off and not incremental build linking
+      # make sure the reference option is turned off and not incremental build linking
       STRING(REPLACE "INCREMENTAL" "INCREMENTAL:NO" replacementFlags ${CMAKE_EXE_LINKER_FLAGS_DEBUG})
       STRING(REPLACE "INCREMENTAL:NO:NO" "INCREMENTAL:NO" replacementFlags1 ${replacementFlags})
-      SET(CMAKE_EXE_LINKER_FLAGS_DEBUG "/INCREMENTAL:NO /OPT:NOREF ${replacementFlags1}" )
+      SET(CMAKE_EXE_LINKER_FLAGS_DEBUG "/INCREMENTAL:NO /OPT:NOREF ${replacementFlags1}")
 
       STRING(REPLACE "INCREMENTAL" "INCREMENTAL:NO" replacementFlags2 ${CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO})
       STRING(REPLACE "INCREMENTAL:NO:NO" "INCREMENTAL:NO" replacementFlags3 ${replacementFlags2})
-      SET(CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO "/INCREMENTAL:NO /OPT:NOREF ${replacementFlags3}" )
+      SET(CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO "/INCREMENTAL:NO /OPT:NOREF ${replacementFlags3}")
 
-      SET(CMAKE_EXE_LINKER_FLAGS_RELEASE "/INCREMENTAL:NO /OPT:NOREF" )
+      SET(CMAKE_EXE_LINKER_FLAGS_RELEASE "/INCREMENTAL:NO /OPT:NOREF")
     endif()
     include_directories(${FluoRender_SOURCE_DIR}/fluorender/FluoRender/WacUtils)
     include_directories(${FluoRender_SOURCE_DIR}/fluorender/Wacom/Include)
@@ -441,32 +508,32 @@ elseif(NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
       $<TARGET_OBJECTS:TRACKING_OBJ>
       $<TARGET_OBJECTS:POLE_OBJ>
       $<TARGET_OBJECTS:TEEM_OBJ>)
-  endif(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
+  endif()
 endif()
 
-#architecture specific rules
+# architecture specific rules
 if(${ARCHITECTURE} MATCHES 64)
-  if(NOT ${CMAKE_SYSTEM_NAME} MATCHES "Windows")
+  if(APPLE)
     set(ARCH_FLAGS "-m64 -arch x86_64")
-  endif(NOT ${CMAKE_SYSTEM_NAME} MATCHES "Windows")
+  endif()
   add_definitions(-DTEEM_32BIT=0)
   set(CMAKE_C_FLAGS "${ARCH_FLAGS} ${CFLAGS}")
-  set(CMAKE_CXX_FLAGS "${ARCH_FLAGS} ${CXXFLAGS} ${CXX_11_FLAG}")
-  set(CMAKE_EXE_LINKER_FLAGS "${ARCH_FLAGS} ${CXX_11_FLAG}")
+  set(CMAKE_CXX_FLAGS "${ARCH_FLAGS} ${CXXFLAGS}")
+  set(CMAKE_EXE_LINKER_FLAGS "${ARCH_FLAGS}")
 else()
-  if(NOT ${CMAKE_SYSTEM_NAME} MATCHES "Windows")
+  if(APPLE)
     set(ARCH_FLAGS "-m32 -arch i386")
-  endif(NOT ${CMAKE_SYSTEM_NAME} MATCHES "Windows")
+  endif()
   add_definitions(-DTEEM_32BIT=1)
-  set(CMAKE_C_FLAGS "${ARCH_FLAGS} ${CFLAGS}" )
-  set(CMAKE_CXX_FLAGS "${ARCH_FLAGS} ${CXXFLAGS} ${CXX_11_FLAG}")
-  set(CMAKE_EXE_LINKER_FLAGS "${ARCH_FLAGS} ${CXX_11_FLAG}")
+  set(CMAKE_C_FLAGS "${ARCH_FLAGS} ${CFLAGS}")
+  set(CMAKE_CXX_FLAGS "${ARCH_FLAGS} ${CXXFLAGS}")
+  set(CMAKE_EXE_LINKER_FLAGS "${ARCH_FLAGS}")
 endif()
 
-if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+if(APPLE)
   set(CMAKE_EXE_LINKER_FLAGS "-L/usr/local/lib -L/usr/lib ${CMAKE_EXE_LINKER_FLAGS} -lbz2 -framework OpenCL -framework CoreFoundation -framework CoreVideo -framework VideoDecodeAcceleration -framework VideoToolbox -framework Security -framework CoreMedia")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mmacosx-version-min=10.9 -DWX_PRECOMP -std=c++11 -stdlib=libc++")
-  #make sure png is static linked
+  # make sure png is static linked
   string(REGEX REPLACE "-lpng" "/usr/local/lib/libpng.a"
     wxWidgets_LIBRARIES ${wxWidgets_LIBRARIES})
   string(REGEX REPLACE "-lpng" "/usr/local/lib/libpng.a"
@@ -476,29 +543,33 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
   message(STATUS "${FREETYPE_LIBRARIES}")
 endif()
 
-#link the libraries
-if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+target_compile_options(FluoRender PRIVATE "$<$<CONFIG:RELEASE>:${RELEASE_FLAGS}>")
+target_compile_options(FluoRender PRIVATE "$<$<CONFIG:DEBUG>:${DEBUG_FLAGS}>")
+
+# link the libraries
+if(UNIX OR APPLE OR MINGW)
   target_link_libraries(FluoRender
-    ${ffmpeg_LIBRARIES}
+    ${FFMPEG_LIBRARIES}
     ${OPENGL_LIBRARIES}
     ${Boost_LIBRARIES}
-    ${OPENCL_LIBRARIES}
+    ${OpenCL_LIBRARIES}
+    ${wxWidgets_LIBRARIES}
     ${FREETYPE_LIBRARIES}
-    ${wxWidgets_LIBRARIES})
-elseif(NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+    ${TIFF_LIBRARIES})
+elseif(WIN32)
   target_link_libraries(FluoRender
     secur32.lib
-    ${ffmpeg_LIBRARIES}
+    ${FFMPEG_LIBRARIES}
     ${OPENGL_LIBRARIES}
     ${Boost_LIBRARIES}
-    ${OPENCL_LIBRARIES}
+    ${OpenCL_LIBRARIES}
     ${FREETYPE_LIBRARIES}
     ${wxWidgets_LIBRARIES})
 endif()
 
 target_link_libraries(SynthBB
   ${Boost_LIBRARIES}
-  ${OPENCL_LIBRARIES}
+  ${OpenCL_LIBRARIES}
   ${wxWidgets_LIBRARIES})
 target_link_libraries(MaskInt
   ${Boost_LIBRARIES}
@@ -507,64 +578,64 @@ target_link_libraries(ReadGMM
   ${Boost_LIBRARIES}
   ${wxWidgets_LIBRARIES})
 
-#build OpenCL examples copies.
 
-#copy openCL examples to the binary directory
+
+# copy openCL examples to the binary directory
 add_custom_command(TARGET FluoRender POST_BUILD
   COMMAND ${CMAKE_COMMAND} -E copy_directory
   "${FluoRender_SOURCE_DIR}/CL_code"
   "$<TARGET_FILE_DIR:FluoRender>/CL_code")
 
-#copy font dir to the binary directory
+# copy font dir to the binary directory
 add_custom_command(TARGET FluoRender POST_BUILD
   COMMAND ${CMAKE_COMMAND} -E copy_directory
   "${FluoRender_SOURCE_DIR}/Fonts"
   "$<TARGET_FILE_DIR:FluoRender>/Fonts")
 
-#copy script dir to the binary directory
+# copy script dir to the binary directory
 add_custom_command(TARGET FluoRender POST_BUILD
   COMMAND ${CMAKE_COMMAND} -E copy_directory
   "${FluoRender_SOURCE_DIR}/Scripts"
   "$<TARGET_FILE_DIR:FluoRender>/Scripts")
 
-#settings files
+# settings files
 add_custom_command(TARGET FluoRender POST_BUILD
   COMMAND ${CMAKE_COMMAND} -E copy_directory
   "${FluoRender_SOURCE_DIR}/Settings"
   "$<TARGET_FILE_DIR:FluoRender>")
 
-#copy data dir to the binary directory
+# copy data dir to the binary directory
 add_custom_command(TARGET FluoRender POST_BUILD
   COMMAND ${CMAKE_COMMAND} -E copy_directory
   "${FluoRender_SOURCE_DIR}/Data"
   "$<TARGET_FILE_DIR:FluoRender>/Data")
 
-#benchmark files
+# benchmark files
 add_custom_command(TARGET FluoRender POST_BUILD
   COMMAND ${CMAKE_COMMAND} -E copy_directory
   "${FluoRender_SOURCE_DIR}/Benchmark"
   "$<TARGET_FILE_DIR:FluoRender>")
 
-#make the Executable dir
-if (WIN32)
-add_custom_target(make_exe_dir ALL 
-  COMMAND ${CMAKE_COMMAND} -E make_directory
-  "$<TARGET_FILE_DIR:FluoRender>/Executables")
+# make the Executable dir
+if(WIN32)
+  add_custom_target(make_exe_dir ALL 
+    COMMAND ${CMAKE_COMMAND} -E make_directory
+    "$<TARGET_FILE_DIR:FluoRender>/Executables")
 else()
   add_custom_command(TARGET FluoRender POST_BUILD 
-  COMMAND ${CMAKE_COMMAND} -E make_directory
-  "$<TARGET_FILE_DIR:FluoRender>/Executables")
+    COMMAND ${CMAKE_COMMAND} -E make_directory
+    "$<TARGET_FILE_DIR:FluoRender>/Executables")
 endif()
-#copy the other binaries into Executables
+# copy the other binaries into Executables
 add_custom_command(TARGET SynthBB POST_BUILD
   COMMAND ${CMAKE_COMMAND} -E copy
-  "$<TARGET_FILE:SynthBB>"
-  "$<TARGET_FILE_DIR:FluoRender>/Executables")
+    "$<TARGET_FILE:SynthBB>"
+    "$<TARGET_FILE_DIR:FluoRender>/Executables")
 add_custom_command(TARGET ReadGMM POST_BUILD
   COMMAND ${CMAKE_COMMAND} -E copy
-  "$<TARGET_FILE:ReadGMM>"
-  "$<TARGET_FILE_DIR:FluoRender>/Executables")
+    "$<TARGET_FILE:ReadGMM>"
+    "$<TARGET_FILE_DIR:FluoRender>/Executables")
 add_custom_command(TARGET MaskInt POST_BUILD
   COMMAND ${CMAKE_COMMAND} -E copy
-  "$<TARGET_FILE:MaskInt>"
-  "$<TARGET_FILE_DIR:FluoRender>/Executables")
+    "$<TARGET_FILE:MaskInt>"
+    "$<TARGET_FILE_DIR:FluoRender>/Executables")

--- a/cmake/Modules/FindFFMPEG.cmake
+++ b/cmake/Modules/FindFFMPEG.cmake
@@ -1,0 +1,263 @@
+#.rst:
+# FindFFMPEG
+# ----------
+#
+# Find the native FFMPEG includes and library
+#
+# This module defines::
+#
+#  FFMPEG_INCLUDE_DIR, where to find avcodec.h, avformat.h ...
+#  FFMPEG_LIBRARIES, the libraries to link against to use FFMPEG.
+#  FFMPEG_FOUND, If false, do not try to use FFMPEG.
+#
+# also defined, but not for general use are::
+#
+#   FFMPEG_avformat_LIBRARY, where to find the FFMPEG avformat library.
+#   FFMPEG_avcodec_LIBRARY, where to find the FFMPEG avcodec library.
+#
+# This is useful to do it this way so that we can always add more libraries
+# if needed to ``FFMPEG_LIBRARIES`` if ffmpeg ever changes...
+
+#=============================================================================
+# Copyright: 1993-2008 Ken Martin, Will Schroeder, Bill Lorensen
+#
+# Distributed under the OSI-approved BSD License (the "License");
+# see accompanying file Copyright.txt for details.
+#
+# This software is distributed WITHOUT ANY WARRANTY; without even the
+# implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the License for more information.
+#=============================================================================
+# (To distribute this file outside of YCM, substitute the full
+#  License text for the above reference.)
+
+# Originally from VTK project
+
+
+find_path(FFMPEG_INCLUDE_DIR1 avformat.h
+  $ENV{FFMPEG_DIR}
+  $ENV{FFMPEG_DIR}/ffmpeg
+  $ENV{FFMPEG_DIR}/libavformat
+  $ENV{FFMPEG_DIR}/include/libavformat
+  $ENV{FFMPEG_DIR}/include/ffmpeg
+  /usr/local/include/ffmpeg
+  /usr/include/ffmpeg
+  /usr/include/libavformat
+  /usr/include/ffmpeg/libavformat
+  /usr/include/${CMAKE_LIBRARY_ARCHITECTURE}/libavformat
+  /usr/local/include/libavformat
+)
+
+find_path(FFMPEG_INCLUDE_DIR2 avutil.h
+  $ENV{FFMPEG_DIR}
+  $ENV{FFMPEG_DIR}/ffmpeg
+  $ENV{FFMPEG_DIR}/libavutil
+  $ENV{FFMPEG_DIR}/include/libavutil
+  $ENV{FFMPEG_DIR}/include/ffmpeg
+  /usr/local/include/ffmpeg
+  /usr/include/ffmpeg
+  /usr/include/libavutil
+  /usr/include/ffmpeg/libavutil
+  /usr/include/${CMAKE_LIBRARY_ARCHITECTURE}/libavutil
+  /usr/local/include/libavutil
+)
+
+find_path(FFMPEG_INCLUDE_DIR3 avcodec.h
+  $ENV{FFMPEG_DIR}
+  $ENV{FFMPEG_DIR}/ffmpeg
+  $ENV{FFMPEG_DIR}/libavcodec
+  $ENV{FFMPEG_DIR}/include/libavcodec
+  $ENV{FFMPEG_DIR}/include/ffmpeg
+  /usr/local/include/ffmpeg
+  /usr/include/ffmpeg
+  /usr/include/libavcodec
+  /usr/include/ffmpeg/libavcodec
+  /usr/include/${CMAKE_LIBRARY_ARCHITECTURE}/libavcodec
+  /usr/local/include/libavcodec
+)
+
+find_path(FFMPEG_INCLUDE_DIR4 swscale.h
+  $ENV{FFMPEG_DIR}
+  $ENV{FFMPEG_DIR}/ffmpeg
+  $ENV{FFMPEG_DIR}/libswscale
+  $ENV{FFMPEG_DIR}/include/libswscale
+  $ENV{FFMPEG_DIR}/include/ffmpeg
+  /usr/local/include/ffmpeg
+  /usr/include/ffmpeg
+  /usr/include/libswscale
+  /usr/include/ffmpeg/libswscale
+  /usr/include/${CMAKE_LIBRARY_ARCHITECTURE}/libswscale
+  /usr/local/include/libswscale
+)
+
+find_path(FFMPEG_INCLUDE_DIR5 swresample.h
+  $ENV{FFMPEG_DIR}
+  $ENV{FFMPEG_DIR}/ffmpeg
+  $ENV{FFMPEG_DIR}/libswresample
+  $ENV{FFMPEG_DIR}/include/libswresample
+  $ENV{FFMPEG_DIR}/include/ffmpeg
+  /usr/local/include/ffmpeg
+  /usr/include/ffmpeg
+  /usr/include/libswresample
+  /usr/include/ffmpeg/libswresample
+  /usr/include/${CMAKE_LIBRARY_ARCHITECTURE}/libswresample
+  /usr/local/include/libswresample
+)
+
+find_path(FFMPEG_INCLUDE_DIR6 avdevice.h
+  $ENV{FFMPEG_DIR}
+  $ENV{FFMPEG_DIR}/ffmpeg
+  $ENV{FFMPEG_DIR}/libavdevice
+  $ENV{FFMPEG_DIR}/include/libavdevice
+  $ENV{FFMPEG_DIR}/include/ffmpeg
+  /usr/local/include/ffmpeg
+  /usr/include/ffmpeg
+  /usr/include/libavdevice
+  /usr/include/ffmpeg/libavdevice
+  /usr/include/${CMAKE_LIBRARY_ARCHITECTURE}/libavdevice
+  /usr/local/include/libavdevice
+)
+
+if(FFMPEG_INCLUDE_DIR1)
+  if(FFMPEG_INCLUDE_DIR2)
+    if(FFMPEG_INCLUDE_DIR3)
+      set(FFMPEG_INCLUDE_DIR ${FFMPEG_INCLUDE_DIR1}
+                             ${FFMPEG_INCLUDE_DIR2}
+                             ${FFMPEG_INCLUDE_DIR3})
+    endif()
+  endif()
+endif()
+
+if(FFMPEG_INCLUDE_DIR4)
+  set(FFMPEG_INCLUDE_DIR ${FFMPEG_INCLUDE_DIR}
+                         ${FFMPEG_INCLUDE_DIR4})
+endif()
+
+if(FFMPEG_INCLUDE_DIR5)
+  set(FFMPEG_INCLUDE_DIR ${FFMPEG_INCLUDE_DIR}
+                         ${FFMPEG_INCLUDE_DIR5})
+endif()
+
+if(FFMPEG_INCLUDE_DIR6)
+  set(FFMPEG_INCLUDE_DIR ${FFMPEG_INCLUDE_DIR}
+                         ${FFMPEG_INCLUDE_DIR6}
+                         ${FFMPEG_INCLUDE_DIR6}/..)
+endif()
+
+find_library(FFMPEG_avformat_LIBRARY avformat
+  $ENV{FFMPEG_DIR}
+  $ENV{FFMPEG_DIR}/lib
+  $ENV{FFMPEG_DIR}/libavformat
+  /usr/local/lib
+  /usr/lib
+)
+
+find_library(FFMPEG_avcodec_LIBRARY avcodec
+  $ENV{FFMPEG_DIR}
+  $ENV{FFMPEG_DIR}/lib
+  $ENV{FFMPEG_DIR}/libavcodec
+  /usr/local/lib
+  /usr/lib
+)
+
+find_library(FFMPEG_avutil_LIBRARY avutil
+  $ENV{FFMPEG_DIR}
+  $ENV{FFMPEG_DIR}/lib
+  $ENV{FFMPEG_DIR}/libavutil
+  /usr/local/lib
+  /usr/lib
+)
+
+if(NOT DISABLE_SWSCALE)
+  find_library(FFMPEG_swscale_LIBRARY swscale
+    $ENV{FFMPEG_DIR}
+    $ENV{FFMPEG_DIR}/lib
+    $ENV{FFMPEG_DIR}/libswscale
+    /usr/local/lib
+    /usr/lib
+  )
+endif(NOT DISABLE_SWSCALE)
+
+if(NOT DISABLE_SWRESAMPLE)
+  find_library(FFMPEG_swresample_LIBRARY swresample
+    $ENV{FFMPEG_DIR}
+    $ENV{FFMPEG_DIR}/lib
+    $ENV{FFMPEG_DIR}/libswresample
+    /usr/local/lib
+    /usr/lib
+  )
+endif(NOT DISABLE_SWRESAMPLE)
+
+find_library(FFMPEG_avdevice_LIBRARY avdevice
+  $ENV{FFMPEG_DIR}
+  $ENV{FFMPEG_DIR}/lib
+  $ENV{FFMPEG_DIR}/libavdevice
+  /usr/local/lib
+  /usr/lib
+)
+
+find_library(_FFMPEG_z_LIBRARY_ z
+  $ENV{FFMPEG_DIR}
+  $ENV{FFMPEG_DIR}/lib
+  /usr/local/lib
+  /usr/lib
+)
+
+
+
+if(FFMPEG_INCLUDE_DIR)
+  if(FFMPEG_avformat_LIBRARY)
+    if(FFMPEG_avcodec_LIBRARY)
+      if(FFMPEG_avutil_LIBRARY)
+        set(FFMPEG_FOUND "YES")
+        set(FFMPEG_LIBRARIES ${FFMPEG_avformat_LIBRARY}
+                             ${FFMPEG_avcodec_LIBRARY}
+                             ${FFMPEG_avutil_LIBRARY}
+          )
+        if(FFMPEG_swscale_LIBRARY)
+          set(FFMPEG_LIBRARIES ${FFMPEG_LIBRARIES}
+                               ${FFMPEG_swscale_LIBRARY}
+          )
+        endif()
+        if(FFMPEG_swresample_LIBRARY)
+          set(FFMPEG_LIBRARIES ${FFMPEG_LIBRARIES}
+                               ${FFMPEG_swresample_LIBRARY}
+          )
+        endif()
+        if(FFMPEG_avdevice_LIBRARY)
+          set(FFMPEG_LIBRARIES ${FFMPEG_LIBRARIES}
+                               ${FFMPEG_avdevice_LIBRARY}
+          )
+        endif()
+        if(_FFMPEG_z_LIBRARY_)
+          set( FFMPEG_LIBRARIES ${FFMPEG_LIBRARIES}
+                                ${_FFMPEG_z_LIBRARY_}
+          )
+        endif()
+      endif()
+    endif()
+  endif()
+endif()
+
+mark_as_advanced(
+  FFMPEG_INCLUDE_DIR
+  FFMPEG_INCLUDE_DIR1
+  FFMPEG_INCLUDE_DIR2
+  FFMPEG_INCLUDE_DIR3
+  FFMPEG_INCLUDE_DIR4
+  FFMPEG_INCLUDE_DIR5
+  FFMPEG_INCLUDE_DIR6
+  FFMPEG_avformat_LIBRARY
+  FFMPEG_avcodec_LIBRARY
+  FFMPEG_avutil_LIBRARY
+  FFMPEG_swscale_LIBRARY
+  FFMPEG_swresample_LIBRARY
+  FFMPEG_avdevice_LIBRARY
+  _FFMPEG_z_LIBRARY_
+)
+
+# Set package properties if FeatureSummary was included
+if(COMMAND set_package_properties)
+  set_package_properties(FFMPEG PROPERTIES DESCRIPTION "A complete, cross-platform solution to record, convert and stream audio and video")
+  set_package_properties(FFMPEG PROPERTIES URL "http://ffmpeg.org/")
+endif()

--- a/fluorender/FluoRender/APropView.cpp
+++ b/fluorender/FluoRender/APropView.cpp
@@ -44,6 +44,9 @@ m_frame(frame),
 m_ann(0),
 m_vrv(0)
 {
+	// temporarily block events during constructor:
+	wxEventBlocker blocker(this);
+
 	wxBoxSizer* sizer_v1 = new wxBoxSizer(wxVERTICAL);
 	wxStaticText* st = 0;
 

--- a/fluorender/FluoRender/AdjustView.cpp
+++ b/fluorender/FluoRender/AdjustView.cpp
@@ -91,6 +91,9 @@ m_dft_sync_r(false),
 m_dft_sync_g(false),
 m_dft_sync_b(false)
 {
+	// temporarily block events during constructor:
+	wxEventBlocker blocker(this);
+
 	this->SetSize(75,-1);
 	//validator: floating point 2
 	wxFloatingPointValidator<double> vald_fp2(2);

--- a/fluorender/FluoRender/Animator/FlKey.h
+++ b/fluorender/FluoRender/Animator/FlKey.h
@@ -37,7 +37,7 @@ using namespace std;
 #define FLKEY_TYPE_BOOLEAN	3
 #define FLKEY_TYPE_INT		4
 
-class KeyCode
+class FlKeyCode
 {
 public:
 	int l0;//view: 1
@@ -47,7 +47,7 @@ public:
 	int l2;//volume property: 0
 	string l2_name;//volume property name
 
-	KeyCode& operator=(const KeyCode& keycode)
+	FlKeyCode& operator=(const FlKeyCode& keycode)
 	{
 		l0 = keycode.l0;
 		l0_name = keycode.l0_name;
@@ -58,7 +58,7 @@ public:
 		return *this;
 	}
 
-	int operator==(const KeyCode& keycode) const
+	int operator==(const FlKeyCode& keycode) const
 	{
 		return l0==keycode.l0 &&
 			l0_name==keycode.l0_name &&
@@ -68,7 +68,7 @@ public:
 			l2_name==keycode.l2_name;
 	}
 
-	int operator!=(const KeyCode& keycode) const
+	int operator!=(const FlKeyCode& keycode) const
 	{
 		return l0!=keycode.l0 ||
 			l0_name!=keycode.l0_name ||
@@ -87,11 +87,11 @@ public:
 	virtual ~FlKey() {};
 
 	virtual int GetType() = 0;
-	KeyCode GetKeyCode()
+	FlKeyCode GetKeyCode()
 	{return m_code;}
 
 protected:
-	KeyCode m_code;
+	FlKeyCode m_code;
 };
 
 #endif//_FLKEY_H_

--- a/fluorender/FluoRender/Animator/FlKeyBoolean.h
+++ b/fluorender/FluoRender/Animator/FlKeyBoolean.h
@@ -43,7 +43,7 @@ public:
 		m_code.l2_name = "";
 		m_bval = false;
 	}
-	FlKeyBoolean(KeyCode keycode, bool bval)
+	FlKeyBoolean(FlKeyCode keycode, bool bval)
 	{
 		m_code = keycode;
 		m_bval = bval;

--- a/fluorender/FluoRender/Animator/FlKeyDouble.h
+++ b/fluorender/FluoRender/Animator/FlKeyDouble.h
@@ -43,7 +43,7 @@ public:
 		m_code.l2_name = "";
 		m_dval = 0.0;
 	}
-	FlKeyDouble(KeyCode keycode, double dval)
+	FlKeyDouble(FlKeyCode keycode, double dval)
 	{
 		m_code = keycode;
 		m_dval = dval;

--- a/fluorender/FluoRender/Animator/FlKeyInt.h
+++ b/fluorender/FluoRender/Animator/FlKeyInt.h
@@ -43,7 +43,7 @@ public:
 		m_code.l2_name = "";
 		m_ival = 0;
 	}
-	FlKeyInt(KeyCode keycode, int ival)
+	FlKeyInt(FlKeyCode keycode, int ival)
 	{
 		m_code = keycode;
 		m_ival = ival;

--- a/fluorender/FluoRender/Animator/FlKeyQuaternion.h
+++ b/fluorender/FluoRender/Animator/FlKeyQuaternion.h
@@ -45,7 +45,7 @@ public:
 		m_code.l2 = 0;
 		m_code.l2_name = "";
 	}
-	FlKeyQuaternion(KeyCode keycode, Quaternion &qval)
+	FlKeyQuaternion(FlKeyCode keycode, Quaternion &qval)
 	{
 		m_code = keycode;
 		m_qval = qval;

--- a/fluorender/FluoRender/Animator/Interpolator.cpp
+++ b/fluorender/FluoRender/Animator/Interpolator.cpp
@@ -336,7 +336,7 @@ void Interpolator::ChangeDuration(int index, double duration)
 	}
 }
 
-bool Interpolator::GetDouble(KeyCode keycode, double t, double &dval)
+bool Interpolator::GetDouble(FlKeyCode keycode, double t, double &dval)
 {
 	int g1 = -1;
 	int g2 = -1;
@@ -386,7 +386,7 @@ bool Interpolator::GetDouble(KeyCode keycode, double t, double &dval)
 	return false;
 }
 
-bool Interpolator::GetBoolean(KeyCode keycode, double t, bool &bval)
+bool Interpolator::GetBoolean(FlKeyCode keycode, double t, bool &bval)
 {
 	int g1 = -1;
 	int g2 = -1;
@@ -428,7 +428,7 @@ bool Interpolator::GetBoolean(KeyCode keycode, double t, bool &bval)
 	return false;
 }
 
-bool Interpolator::GetInt(KeyCode keycode, double t, int &ival)
+bool Interpolator::GetInt(FlKeyCode keycode, double t, int &ival)
 {
 	int g1 = -1;
 	int g2 = -1;
@@ -470,7 +470,7 @@ bool Interpolator::GetInt(KeyCode keycode, double t, int &ival)
 	return false;
 }
 
-bool Interpolator::GetQuaternion(KeyCode keycode, double t, Quaternion &qval)
+bool Interpolator::GetQuaternion(FlKeyCode keycode, double t, Quaternion &qval)
 {
 	int g1 = -1;
 	int g2 = -1;
@@ -521,7 +521,7 @@ bool Interpolator::GetQuaternion(KeyCode keycode, double t, Quaternion &qval)
 }
 
 //search
-FlKey* Interpolator::SearchKey(KeyCode keycode, FlKeyGroup* g)
+FlKey* Interpolator::SearchKey(FlKeyCode keycode, FlKeyGroup* g)
 {
 	if (!g) return 0;
 	for (int i=0; i<(int)g->keys.size(); i++)
@@ -531,7 +531,7 @@ FlKey* Interpolator::SearchKey(KeyCode keycode, FlKeyGroup* g)
 }
 
 //interpolations
-bool Interpolator::StepDouble(KeyCode keycode, FlKeyGroup* g, double &dval)
+bool Interpolator::StepDouble(FlKeyCode keycode, FlKeyGroup* g, double &dval)
 {
 	dval = 0.0;
 	if (!g) return false;
@@ -542,7 +542,7 @@ bool Interpolator::StepDouble(KeyCode keycode, FlKeyGroup* g, double &dval)
 	return true;
 }
 
-bool Interpolator::LinearDouble(KeyCode keycode, FlKeyGroup* g1, FlKeyGroup* g2, double t, double &dval)
+bool Interpolator::LinearDouble(FlKeyCode keycode, FlKeyGroup* g1, FlKeyGroup* g2, double t, double &dval)
 {
 	dval = 0.0;
 	if (!g1 || !g2) return false;
@@ -567,7 +567,7 @@ bool Interpolator::LinearDouble(KeyCode keycode, FlKeyGroup* g1, FlKeyGroup* g2,
 	return true;
 }
 
-bool Interpolator::StepQuaternion(KeyCode keycode, FlKeyGroup* g, Quaternion &qval)
+bool Interpolator::StepQuaternion(FlKeyCode keycode, FlKeyGroup* g, Quaternion &qval)
 {
 	qval = Quaternion(0, 0, 0, 1);
 	if (!g) return false;
@@ -579,7 +579,7 @@ bool Interpolator::StepQuaternion(KeyCode keycode, FlKeyGroup* g, Quaternion &qv
 	return true;
 }
 
-bool Interpolator::LinearQuaternion(KeyCode keycode, FlKeyGroup* g1, FlKeyGroup* g2, double t, Quaternion &qval)
+bool Interpolator::LinearQuaternion(FlKeyCode keycode, FlKeyGroup* g1, FlKeyGroup* g2, double t, Quaternion &qval)
 {
 	qval = Quaternion(0, 0, 0, 1);
 	if (!g1 || !g2) return false;

--- a/fluorender/FluoRender/Animator/Interpolator.h
+++ b/fluorender/FluoRender/Animator/Interpolator.h
@@ -89,10 +89,10 @@ public:
 	void MoveKeyAfter(int from_idx, int to_idx);
 
 	//get values
-	bool GetDouble(KeyCode keycode, double t, double &dval);
-	bool GetQuaternion(KeyCode keycode, double t, Quaternion &qval);
-	bool GetBoolean(KeyCode keycode, double t, bool &bval);
-	bool GetInt(KeyCode keycode, double t, int &ival);
+	bool GetDouble(FlKeyCode keycode, double t, double &dval);
+	bool GetQuaternion(FlKeyCode keycode, double t, Quaternion &qval);
+	bool GetBoolean(FlKeyCode keycode, double t, bool &bval);
+	bool GetInt(FlKeyCode keycode, double t, int &ival);
 
 	static int m_id;
 
@@ -102,11 +102,11 @@ private:
 	vector<FlKeyGroup*> m_key_list;
 
 private:
-	FlKey* SearchKey(KeyCode keycode, FlKeyGroup* g);
-	bool StepDouble(KeyCode keycode, FlKeyGroup* g, double &dval);
-	bool LinearDouble(KeyCode keycode, FlKeyGroup* g1, FlKeyGroup* g2, double t, double &dval);
-	bool StepQuaternion(KeyCode keycode, FlKeyGroup* g, Quaternion &qval);
-	bool LinearQuaternion(KeyCode keycode, FlKeyGroup* g1, FlKeyGroup* g2, double t, Quaternion &qval);
+	FlKey* SearchKey(FlKeyCode keycode, FlKeyGroup* g);
+	bool StepDouble(FlKeyCode keycode, FlKeyGroup* g, double &dval);
+	bool LinearDouble(FlKeyCode keycode, FlKeyGroup* g1, FlKeyGroup* g2, double t, double &dval);
+	bool StepQuaternion(FlKeyCode keycode, FlKeyGroup* g, Quaternion &qval);
+	bool LinearQuaternion(FlKeyCode keycode, FlKeyGroup* g1, FlKeyGroup* g2, double t, Quaternion &qval);
 	double Smooth(double ft, bool s1, bool s2);
 
 };

--- a/fluorender/FluoRender/BrushToolDlg.cpp
+++ b/fluorender/FluoRender/BrushToolDlg.cpp
@@ -91,6 +91,9 @@ BrushToolDlg::BrushToolDlg(wxWindow *frame, wxWindow *parent)
 	m_dft_gm_falloff(0.0),
 	m_dft_scl_translate(0.0)
 {
+	// temporarily block events during constructor:
+	wxEventBlocker blocker(this);
+
 	wxStaticText *st = 0;
 	//validator: floating point 1
 	wxFloatingPointValidator<double> vald_fp1(1);

--- a/fluorender/FluoRender/CalculationDlg.cpp
+++ b/fluorender/FluoRender/CalculationDlg.cpp
@@ -52,6 +52,9 @@ CalculationDlg::CalculationDlg(wxWindow *frame, wxWindow *parent)
 		m_frame(frame),
 		m_group(0)
 {
+	// temporarily block events during constructor:
+	wxEventBlocker blocker(this);
+
 	wxStaticText *st = 0;
 
 	//operand A

--- a/fluorender/FluoRender/ClippingView.cpp
+++ b/fluorender/FluoRender/ClippingView.cpp
@@ -100,6 +100,9 @@ m_link_x(false),
 m_link_y(false),
 m_link_z(false)
 {
+	// temporarily block events during constructor:
+	wxEventBlocker blocker(this);
+
 	//validator: floating point 1
 	wxFloatingPointValidator<double> vald_fp1(1);
 	vald_fp1.SetRange(-180.0, 180.0);

--- a/fluorender/FluoRender/ColocalizationDlg.cpp
+++ b/fluorender/FluoRender/ColocalizationDlg.cpp
@@ -50,6 +50,9 @@ m_view(0),
 m_vol_a(0),
 m_vol_b(0)
 {
+	// temporarily block events during constructor:
+	wxEventBlocker blocker(this);
+
 	//validator: integer
 	wxIntegerValidator<unsigned int> vald_int;
 

--- a/fluorender/FluoRender/ComponentDlg.cpp
+++ b/fluorender/FluoRender/ComponentDlg.cpp
@@ -1175,6 +1175,9 @@ ComponentDlg::ComponentDlg(wxWindow *frame, wxWindow *parent)
 	m_frame(parent),
 	m_view(0)
 {
+	// temporarily block events during constructor:
+	wxEventBlocker blocker(this);
+
 	//notebook
 	m_notebook = new wxNotebook(this, ID_Notebook);
 	m_notebook->AddPage(Create3DAnalysisPage(m_notebook), "Basic");

--- a/fluorender/FluoRender/Components/CompGenerator.h
+++ b/fluorender/FluoRender/Components/CompGenerator.h
@@ -28,7 +28,7 @@ DEALINGS IN THE SOFTWARE.
 #ifndef FL_CompGenerator_h
 #define FL_CompGenerator_h
 
-#ifdef _WIN32
+#if defined(_WIN32) || defined(__linux__)
 #include <CL/cl.h>
 #endif
 #ifdef _DARWIN

--- a/fluorender/FluoRender/ConvertDlg.cpp
+++ b/fluorender/FluoRender/ConvertDlg.cpp
@@ -48,6 +48,9 @@ wxPanel(parent, wxID_ANY,
 	0, "ConvertDlg"),
 	m_frame(parent)
 {
+	// temporarily block events during constructor:
+	wxEventBlocker blocker(this);
+
 	//validator: floating point 2
 	wxFloatingPointValidator<double> vald_fp2(2);
 	//validator: integer

--- a/fluorender/FluoRender/CountingDlg.cpp
+++ b/fluorender/FluoRender/CountingDlg.cpp
@@ -52,6 +52,9 @@ m_view(0),
 m_max_value(255.0),
 m_dft_thresh(0.0)
 {
+	// temporarily block events during constructor:
+	wxEventBlocker blocker(this);
+
 	//validator: floating point 1
 	wxFloatingPointValidator<double> vald_fp1(1);
 	//validator: integer

--- a/fluorender/FluoRender/FLIVR/KernelProgram.h
+++ b/fluorender/FluoRender/FLIVR/KernelProgram.h
@@ -2,7 +2,7 @@
 #define KernelProgram_h
 
 #include <GL/glew.h>
-#ifdef _WIN32
+#if defined(_WIN32) || defined(__linux__)
 #include <CL/cl.h>
 #include <CL/cl_gl.h>
 #endif

--- a/fluorender/FluoRender/FLIVR/MeshRenderer.h
+++ b/fluorender/FluoRender/FLIVR/MeshRenderer.h
@@ -34,6 +34,7 @@
 #include "glm.h"
 #include "Plane.h"
 #include <vector>
+#include <cstring>
 #include <glm/glm.hpp>
 
 using namespace std;

--- a/fluorender/FluoRender/FLIVR/ShaderProgram.cpp
+++ b/fluorender/FluoRender/FLIVR/ShaderProgram.cpp
@@ -30,7 +30,7 @@
 #include "ShaderProgram.h"
 #include "Utils.h"
 #include "../compatibility.h"
-#include <time.h>
+#include <ctime>
 #include <cstdio>
 #include <sstream>
 #include <iostream>

--- a/fluorender/FluoRender/FLIVR/TextureRenderer.cpp
+++ b/fluorender/FluoRender/FLIVR/TextureRenderer.cpp
@@ -27,7 +27,7 @@
 //  
 
 #include <GL/glew.h>
-#include <FLIVR/texturebrick.h>
+#include <FLIVR/TextureBrick.h>
 #include <FLIVR/TextureRenderer.h>
 #include <FLIVR/Color.h>
 #include <FLIVR/Utils.h>

--- a/fluorender/FluoRender/FLIVR/Transform.cpp
+++ b/fluorender/FluoRender/FLIVR/Transform.cpp
@@ -29,6 +29,7 @@ DEALINGS IN THE SOFTWARE.
 #include <FLIVR/Transform.h>
 #include <FLIVR/Point.h>
 #include <FLIVR/Plane.h>
+#include <cstring>
 #include <iostream>
 
 using namespace FLIVR;

--- a/fluorender/FluoRender/HelpDlg.cpp
+++ b/fluorender/FluoRender/HelpDlg.cpp
@@ -37,6 +37,9 @@ wxPanel(parent, wxID_ANY,
 		 0, "HelpDlg"),
 m_html(0)
 {
+	// temporarily block events during constructor:
+	wxEventBlocker blocker(this);
+
 	m_name = "";
 	wxBoxSizer *sizer = new wxBoxSizer(wxVERTICAL);
 	m_html = new wxHtmlWindow(this);

--- a/fluorender/FluoRender/ListPanel.cpp
+++ b/fluorender/FluoRender/ListPanel.cpp
@@ -61,6 +61,9 @@ DataListCtrl::DataListCtrl(
 	wxListCtrl(parent, id, pos, size, style),
 	m_frame(frame)
 {
+	// temporarily block events during constructor:
+	wxEventBlocker blocker(this);
+
 	wxListItem itemCol;
 	itemCol.SetText("Type");
 	this->InsertColumn(0, itemCol);
@@ -914,6 +917,9 @@ ListPanel::ListPanel(wxWindow *frame,
 	wxPanel(parent, id, pos, size, style, name)//,
 	//m_frame(frame)
 {
+	// temporarily block events during constructor:
+	wxEventBlocker blocker(this);
+
 	//create data list
 	m_datalist = new DataListCtrl(frame, this, wxID_ANY);
 

--- a/fluorender/FluoRender/MManipulator.cpp
+++ b/fluorender/FluoRender/MManipulator.cpp
@@ -44,6 +44,9 @@ wxPanel(parent, id, pos, size, style, name),
 m_frame(frame),
 m_md(0)
 {
+	// temporarily block events during constructor:
+	wxEventBlocker blocker(this);
+
 	wxBoxSizer* sizer_v = new wxBoxSizer(wxVERTICAL);
 	wxBoxSizer* sizer_1 = new wxBoxSizer(wxHORIZONTAL);
 	wxBoxSizer* sizer_2 = new wxBoxSizer(wxHORIZONTAL);

--- a/fluorender/FluoRender/MPropView.cpp
+++ b/fluorender/FluoRender/MPropView.cpp
@@ -61,6 +61,9 @@ m_frame(frame),
 m_md(0),
 m_vrv(0)
 {
+	// temporarily block events during constructor:
+	wxEventBlocker blocker(this);
+
 	wxBoxSizer* sizer_v1 = new wxBoxSizer(wxVERTICAL);
 	wxBoxSizer* sizer_1 = new wxBoxSizer(wxHORIZONTAL);
 	wxBoxSizer* sizer_2 = new wxBoxSizer(wxHORIZONTAL);

--- a/fluorender/FluoRender/MeasureDlg.cpp
+++ b/fluorender/FluoRender/MeasureDlg.cpp
@@ -47,9 +47,9 @@ BEGIN_EVENT_TABLE(RulerListCtrl, wxListCtrl)
 	EVT_COLOURPICKER_CHANGED(ID_ColorPicker, RulerListCtrl::OnColorChange)
 	EVT_SCROLLWIN(RulerListCtrl::OnScroll)
 	EVT_MOUSEWHEEL(RulerListCtrl::OnScroll)
-	END_EVENT_TABLE()
+END_EVENT_TABLE()
 
-	RulerListCtrl::RulerListCtrl(
+RulerListCtrl::RulerListCtrl(
 	wxWindow* frame,
 	wxWindow* parent,
 	wxWindowID id,
@@ -59,6 +59,9 @@ BEGIN_EVENT_TABLE(RulerListCtrl, wxListCtrl)
 wxListCtrl(parent, id, pos, size, style)//,
 	//m_frame(frame)
 {
+	// temporarily block events during constructor:
+	wxEventBlocker blocker(this);
+
 	wxListItem itemCol;
 	itemCol.SetText("Name");
 	this->InsertColumn(0, itemCol);
@@ -509,15 +512,18 @@ BEGIN_EVENT_TABLE(MeasureDlg, wxPanel)
 	EVT_RADIOBUTTON(ID_AccIntensityRd, MeasureDlg::OnIntensityMethodCheck)
 	EVT_CHECKBOX(ID_UseTransferChk, MeasureDlg::OnUseTransferCheck)
 	EVT_CHECKBOX(ID_TransientChk, MeasureDlg::OnTransientCheck)
-	END_EVENT_TABLE()
+END_EVENT_TABLE()
 
-	MeasureDlg::MeasureDlg(wxWindow* frame, wxWindow* parent)
+MeasureDlg::MeasureDlg(wxWindow* frame, wxWindow* parent)
 	: wxPanel(parent,wxID_ANY,
 	wxDefaultPosition, wxSize(650, 600),
 	0, "MeasureDlg"),
 	m_frame(parent),
 	m_view(0)
 {
+	// temporarily block events during constructor:
+	wxEventBlocker blocker(this);
+
 	//toolbar
 	m_toolbar = new wxToolBar(this, wxID_ANY, wxDefaultPosition, wxDefaultSize,
 		wxTB_FLAT|wxTB_TOP|wxTB_NODIVIDER|wxTB_TEXT);

--- a/fluorender/FluoRender/NoiseCancellingDlg.cpp
+++ b/fluorender/FluoRender/NoiseCancellingDlg.cpp
@@ -50,6 +50,9 @@ NoiseCancellingDlg::NoiseCancellingDlg(wxWindow *frame, wxWindow *parent)
 	m_dft_size(50),
 	m_previewed(false)
 {
+	// temporarily block events during constructor:
+	wxEventBlocker blocker(this);
+
 	//validator: floating point 1
 	wxFloatingPointValidator<double> vald_fp1(1);
 	//validator: integer

--- a/fluorender/FluoRender/OclDlg.cpp
+++ b/fluorender/FluoRender/OclDlg.cpp
@@ -51,6 +51,9 @@ wxDefaultPosition, wxSize(550, 600),
 m_frame(parent),
 m_view(0)
 {
+	// temporarily block events during constructor:
+	wxEventBlocker blocker(this);
+
 	wxStaticText *st = 0;
 	//
 	wxBoxSizer* sizer_1 = new wxBoxSizer(wxHORIZONTAL);

--- a/fluorender/FluoRender/RecorderDlg.cpp
+++ b/fluorender/FluoRender/RecorderDlg.cpp
@@ -705,7 +705,7 @@ void RecorderDlg::InsertKey(int index, double duration, int interpolation)
 	Interpolator *interpolator = vr_frame->GetInterpolator();
 	if (!interpolator)
 		return;
-	KeyCode keycode;
+	FlKeyCode keycode;
 	FlKeyDouble* flkey = 0;
 	FlKeyQuaternion* flkeyQ = 0;
 	FlKeyBoolean* flkeyB = 0;
@@ -930,7 +930,7 @@ void RecorderDlg::AutoKeyChanComb(int comb)
 	double duration;
 	str.ToDouble(&duration);
 
-	KeyCode keycode;
+	FlKeyCode keycode;
 	FlKeyBoolean* flkeyB = 0;
 
 	double t = interpolator->GetLastT();

--- a/fluorender/FluoRender/RecorderDlg.cpp
+++ b/fluorender/FluoRender/RecorderDlg.cpp
@@ -58,6 +58,9 @@ m_frame(frame),
 m_editing_item(-1),
 m_dragging_to_item(-1)
 {
+	// temporarily block events during constructor:
+	wxEventBlocker blocker(this);
+
 	//validator: integer
 	wxIntegerValidator<unsigned int> vald_int;
 
@@ -529,6 +532,9 @@ wxPoint(500, 150), wxSize(450, 600),
 m_frame(frame),
 m_view(0)
 {
+	// temporarily block events during constructor:
+	wxEventBlocker blocker(this);
+
 	//validator: integer
 	wxIntegerValidator<unsigned int> vald_int;
 	wxStaticText* st = 0;

--- a/fluorender/FluoRender/SettingDlg.cpp
+++ b/fluorender/FluoRender/SettingDlg.cpp
@@ -521,6 +521,9 @@ SettingDlg::SettingDlg(wxWindow *frame, wxWindow *parent) :
 		0, "SettingDlg"),
 	m_frame(frame)
 {
+	// temporarily block events during constructor:
+	wxEventBlocker blocker(this);
+
 	//notebook
 	wxNotebook *notebook = new wxNotebook(this, wxID_ANY);
 	notebook->AddPage(CreateProjectPage(notebook), "Project");

--- a/fluorender/FluoRender/Tester.cpp
+++ b/fluorender/FluoRender/Tester.cpp
@@ -58,6 +58,9 @@ m_p3(0.0),
 m_p4(0.0)//,
 //m_frame(frame)
 {
+	// temporarily block events during constructor:
+	wxEventBlocker blocker(this);
+
 /*	wxStaticText *st;
 
 	//p1

--- a/fluorender/FluoRender/TraceDlg.cpp
+++ b/fluorender/FluoRender/TraceDlg.cpp
@@ -60,6 +60,9 @@ TraceListCtrl::TraceListCtrl(
 	wxListCtrl(parent, id, pos, size, style),
 	m_type(0)
 {
+	// temporarily block events during constructor:
+	wxEventBlocker blocker(this);
+
 	wxListItem itemCol;
 	itemCol.SetText("");
 	InsertColumn(0, itemCol);
@@ -774,6 +777,9 @@ TraceDlg::TraceDlg(wxWindow* frame, wxWindow* parent)
 	m_manual_assist(false),
 	m_auto_id(false)
 {
+	// temporarily block events during constructor:
+	wxEventBlocker blocker(this);
+
 	//validator: integer
 	wxIntegerValidator<unsigned int> vald_int;
 

--- a/fluorender/FluoRender/TreePanel.cpp
+++ b/fluorender/FluoRender/TreePanel.cpp
@@ -64,9 +64,9 @@ BEGIN_EVENT_TABLE(DataTreeCtrl, wxTreeCtrl)
 	EVT_TREE_END_DRAG(wxID_ANY, DataTreeCtrl::OnEndDrag)
 	EVT_KEY_DOWN(DataTreeCtrl::OnKeyDown)
 	EVT_KEY_UP(DataTreeCtrl::OnKeyUp)
-	END_EVENT_TABLE()
+END_EVENT_TABLE()
 
-	DataTreeCtrl::DataTreeCtrl(
+DataTreeCtrl::DataTreeCtrl(
 	wxWindow* frame,
 	wxWindow* parent,
 	wxWindowID id,
@@ -78,6 +78,9 @@ wxTreeCtrl(parent, id, pos, size, style),
 	m_fixed(false),
 	m_scroll_pos(-1)
 {
+	// temporarily block events during constructor:
+	wxEventBlocker blocker(this);
+
 	wxImageList *images = new wxImageList(16, 16, true);
 	wxIcon icons[2];
 	icons[0] = wxIcon(cross_xpm);

--- a/fluorender/FluoRender/VMovieView.cpp
+++ b/fluorender/FluoRender/VMovieView.cpp
@@ -418,6 +418,9 @@ m_current_page(0),
 m_rot_int_type(0),
 m_delayed_stop(false)
 {
+	// temporarily block events during constructor:
+	wxEventBlocker blocker(this);
+
 	//notebook
 	m_notebook = new wxNotebook(this, wxID_ANY);
 	m_notebook->AddPage(CreateSimplePage(m_notebook), "Basic");

--- a/fluorender/FluoRender/VPropView.cpp
+++ b/fluorender/FluoRender/VPropView.cpp
@@ -127,6 +127,9 @@ wxPanel(parent, id, pos, size,style, name),
 	m_space_y_text(0),
 	m_space_z_text(0)
 {
+	// temporarily block events during constructor:
+	wxEventBlocker blocker(this);
+
 	wxBoxSizer* sizer_all = new wxBoxSizer(wxHORIZONTAL);
 	wxBoxSizer* sizer_left = new wxBoxSizer(wxVERTICAL);
 	wxBoxSizer* sizer_middle = new wxBoxSizer(wxVERTICAL);

--- a/fluorender/FluoRender/VRenderFrame.cpp
+++ b/fluorender/FluoRender/VRenderFrame.cpp
@@ -2928,7 +2928,7 @@ void VRenderFrame::SaveProject(wxString& filename)
 					fconfig.SetPath(str);
 					int key_type = key->GetType();
 					fconfig.Write("type", key_type);
-					KeyCode code = key->GetKeyCode();
+					FlKeyCode code = key->GetKeyCode();
 					fconfig.Write("l0", code.l0);
 					str = code.l0_name;
 					fconfig.Write("l0_name", str);
@@ -4361,7 +4361,7 @@ void VRenderFrame::OpenProject(wxString& filename)
 							int key_type;
 							if (fconfig.Read("type", &key_type))
 							{
-								KeyCode code;
+								FlKeyCode code;
 								if (fconfig.Read("l0", &iVal))
 									code.l0 = iVal;
 								if (fconfig.Read("l0_name", &sVal))

--- a/fluorender/FluoRender/VRenderView.cpp
+++ b/fluorender/FluoRender/VRenderView.cpp
@@ -11504,6 +11504,9 @@ wxPanel(parent, id, pos, size, style),
 	m_dft_scale_factor(1.0),
 	m_dft_scale_factor_mode(true)
 {
+	// temporarily block events during constructor:
+	wxEventBlocker blocker(this);
+
 	wxLogNull logNo;
 	//full frame
 	m_full_frame = new wxFrame((wxFrame*)NULL, wxID_ANY, "FluoRender");

--- a/fluorender/FluoRender/VRenderView.cpp
+++ b/fluorender/FluoRender/VRenderView.cpp
@@ -4823,7 +4823,7 @@ void VRenderGLView::SetParams(double t)
 	Interpolator *interpolator = vr_frame->GetInterpolator();
 	if(!interpolator)
 		return;
-	KeyCode keycode;
+	FlKeyCode keycode;
 	keycode.l0 = 1;
 	keycode.l0_name = m_vrv->GetName();
 

--- a/fluorender/FluoRender/VRenderView.cpp
+++ b/fluorender/FluoRender/VRenderView.cpp
@@ -5678,6 +5678,7 @@ void VRenderGLView::RunSeparateChannels(wxFileConfig &fconfig)
 
 void VRenderGLView::RunExternalExe(wxFileConfig &fconfig)
 {
+#ifndef __linux__
 	wxString pathname;
 	fconfig.Read("exepath", &pathname);
 	if (!wxFileExists(pathname))
@@ -5699,6 +5700,7 @@ void VRenderGLView::RunExternalExe(wxFileConfig &fconfig)
 		boost::process::launch(pathname.ToStdString(),
 		args, ctx);
 	c.wait();
+#endif
 }
 
 void VRenderGLView::RunFetchMask(wxFileConfig &fconfig)
@@ -5959,7 +5961,7 @@ void VRenderGLView::ForceDraw()
 		}
 	}
 #endif
-#ifdef _DARWIN
+#if defined(_DARWIN) || defined(__linux__)
 	SetCurrent(*m_glRC);
 #endif
 	Init();
@@ -11478,9 +11480,9 @@ BEGIN_EVENT_TABLE(VRenderView, wxPanel)
 	EVT_TOOL(ID_DefaultBtn, VRenderView::OnSaveDefault)
 
 	EVT_KEY_DOWN(VRenderView::OnKeyDown)
-	END_EVENT_TABLE()
+END_EVENT_TABLE()
 
-	VRenderView::VRenderView(wxWindow* frame,
+VRenderView::VRenderView(wxWindow* frame,
 	wxWindow* parent,
 	wxWindowID id,
 	wxGLContext* sharedContext,

--- a/fluorender/FluoRender/VRenderView.h
+++ b/fluorender/FluoRender/VRenderView.h
@@ -25,6 +25,10 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 */
+
+#ifndef _VRENDERVIEW_H_
+#define _VRENDERVIEW_H_
+
 #include "DataManager.h"
 #include "utility.h"
 #include "VolumeSelector.h"
@@ -51,12 +55,9 @@ DEALINGS IN THE SOFTWARE.
 
 #include <vector>
 #include <stdarg.h>
-#include "nv/timer.h"
+#include "NV/Timer.h"
 
 #include <glm/glm.hpp>
-
-#ifndef _VRENDERVIEW_H_
-#define _VRENDERVIEW_H_
 
 #define VOL_METHOD_SEQ    1
 #define VOL_METHOD_MULTI  2

--- a/fluorender/FluoRender/Video/QVideoEncoder.cpp
+++ b/fluorender/FluoRender/Video/QVideoEncoder.cpp
@@ -33,6 +33,7 @@
 //FYI: FFmpeg is a pure C project using C99 math features, 
 //in order to enable C++ to use them you have to append -D__STDC_CONSTANT_MACROS to your CXXFLAGS
 
+#include <cstring>
 #include "QVideoEncoder.h"
 
 QVideoEncoder::QVideoEncoder() {
@@ -411,7 +412,7 @@ bool QVideoEncoder::set_frame_rgb_data(unsigned char * data) {
 	}
 	//this is where data gets cropped if width/height are not divisible by 16
 	for(size_t i = 0; i < height_; i++)
-		memcpy(
+		std::memcpy(
 		aligned_data + (3 * i * width_),
 		data         + (3 * i * actual_width_),
 		3 * width_);

--- a/fluorender/FluoRender/compatibility.h
+++ b/fluorender/FluoRender/compatibility.h
@@ -41,12 +41,14 @@ DEALINGS IN THE SOFTWARE.
 #include <cstdarg>
 #include <cstdint>
 #include <string>
+#include <cstring> 
+#include <locale>
 #include <vector>
 #include <windows.h>
 #include <ole2.h>
 #include <wintab.h>
 #include <pktdef.h>
-#include <time.h>
+#include <ctime>
 #include <sys/types.h>
 #include <ctype.h>
 #include <wx/wx.h>
@@ -293,6 +295,9 @@ inline void FIND_FILES(std::wstring m_path_name,
 
 #else // MAC OSX or LINUX
 
+#include <string>
+#include <cstring> 
+#include <locale>
 #include <unistd.h>
 #include <dirent.h>
 #include <sys/time.h>


### PR DESCRIPTION
This PR adds Linux support. It was tested on Ubuntu 16.04 with gcc 5.4 and wxWidgets 3.1 (with
the official release of wxWidgets, manually built and installed on Ubuntu). A larger change is the
use of the event blocker `wxEventBlocker` in commit a4b2fd9. This event blocker is required with
wxWidgets 3.1 on Ubuntu, unless I'm doing something wrong. Without this blocker, the constructor
will create i.e. new text fields, and the creation will trigger a "text field changed" event inside the
constructor, leading to a crash (because the text field pointer is still NULL). I think this change is good
for all architectures and will make the code more stable.