### PR TITLE
Building on Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -256,7 +256,7 @@ elseif(APPLE)
 else()
   find_package(FFMPEG REQUIRED)
   #string(REPLACE "/usr/include/" "" FFMPEG_INCLUDE_DIR "${FFMPEG_INCLUDE_DIR}")
-  #include_directories(${FFMPEG_INCLUDE_DIR})
+  include_directories(${FFMPEG_INCLUDE_DIR})
 endif()
 
 # FluoRender
@@ -576,6 +576,8 @@ if(APPLE)
   string(REGEX REPLACE "/usr/local/lib/libfreetype.dylib" "/usr/local/lib/libfreetype.a;/usr/local/lib/libpng.a"
     FREETYPE_LIBRARIES ${FREETYPE_LIBRARIES})
   message(STATUS "${FREETYPE_LIBRARIES}")
+elseif(UNIX OR MINGW)
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -lpthread -ldl")
 endif()
 
 target_compile_options(FluoRender PRIVATE "$<$<CONFIG:RELEASE>:${RELEASE_FLAGS}>")

--- a/build_linux.txt
+++ b/build_linux.txt
@@ -53,3 +53,17 @@ CMakeFiles/FluoRender.dir/link.txt
 $ make
 $ make install
 
+Issues
+
+- works with OpenCL shipped with Nvidia driver 390, but segfaults in /lib64/libnvidia-opencl.so.1 with driver 410
+- the same crash seems to happen even with 390 when using hardware OpenGL.
+- with driver 390, even though the GUI starts, there are several errors:
+Error while getting JNI_CreateJavaVM funciton address.
+./src/unix/glx11.cpp(565): assert ""xid"" failed in SetCurrent(): window must be shown
+Error while getting JNI_CreateJavaVM funciton address.
+16:02:08: Debug: Failed to connect to session manager: SESSION_MANAGER environment variable not defined
+Error while getting JNI_CreateJavaVM funciton address.
+Error compiling vertex shader: 0(3) : error C0000: syntax error, unexpected '(', expecting "::" at token "("
+0(10) : error C1503: undefined variable "InVertex"
+0(11) : error C1503: undefined variable "InTexCoord"
+0(12) : error C1503: undefined variable "InVertex" 

--- a/build_linux.txt
+++ b/build_linux.txt
@@ -1,0 +1,55 @@
+Building on Linux
+
+1. Install dependencies
+
+1.a. GNU compilers >= 5.0 (at CHPC "module load gcc/5.4.0)
+
+1.b. BOOST (at CHPC "module load boost/1.66.0")
+
+1.c. wxWidgets, download and build, e.g.
+$ wget https://github.com/wxWidgets/wxWidgets/releases/download/v3.0.4/wxWidgets-3.0.4.tar.bz2
+$ tar xf wxWidgets-3.0.4.tar.bz2
+$ mv wxWidgets-3.0.4 3.0.4--5.4.0g
+$ cd 3.0.4--5.4.0g/
+$ module load gcc/5.4.0
+$ ./configure --prefix=/uufs/chpc.utah.edu/sys/installdir/wxWidgets/3.0.4-5.4.0g --with-libpng --with-libjpeg --with-libtiff --with-libxpm --with-libiconv --with-libnotify --with-opengl --with-regex --with-zlib --enable-cxx11 --enable-stl --enable-monolithic
+$ make
+$ make install
+
+1.d. ffmpeg, download and build
+$ wget https://ffmpeg.org/releases/ffmpeg-4.0.2.tar.bz2
+$ tar xf ffmpeg-4.0.2.tar.bz2
+$ mv ffmpeg-4.0.2 4.0.2
+$ cd 4.0.2
+$ module load gcc/5.4.0
+$ ./configure --prefix=/uufs/chpc.utah.edu/sys/installdir/ffmpeg/4.0.2
+$ make
+$ make install
+
+2. Download, modify and build fluorender
+$ git clone https://github.com/mcuma/fluorender (this includes some Linux
+based modifications)
+$ cd fluorender
+$ mkdir build
+$ cd build
+$ module load gcc/5.4.0 cmake/3.11.2 wxWidgets/3.0.4 (wxWidgets wx-config
+needs to be in the PATH for cmake configure to find it)
+$ cmake --debug-trycompile -DCMAKE_INSTALL_PREFIX=./ -DCMAKE_CXX_COMPILER=/uufs/chpc.utah.edu/sys/installdir/gcc/5.4.0-c7/bin/c++ -DCMAKE_C_COMPILER=/uufs/chpc.utah.edu/sys/installdir/gcc/5.4.0-c7/bin/gcc -DBOOST_ROOT=/uufs/chpc.utah.edu/sys/installdir/boost/1.66.0-5.4.0g -DOpenCL_INCLUDE_DIR=/usr/local/cuda/include -DOpenCL_LIBRARY=/usr/lib64/libOpenCL.so.1 -DCMAKE_CXX_FLAGS=-std=c++11 -DFFMPEG_DIR=/uufs/chpc.utah.edu/sys/installdir/ffmpeg/4.0.2 ..
+(CXX_COMPILER and C_COMPILER need to be specified otherwise the distro based
+compiler is found first by cmake)
+
+after configure is done, need to modify a few files to add FFMPEG paths (which
+I can't figure out easily in the CMakeLists.txt):
+CMakeFiles/FluoRender.dir/flags.make (make sure to scroll down to CXX_FLAGS, on top is C_FLAGS)
+CMakeFiles/VIDEO_OBJ.dir/flags.make
+
+CXX_FLAGS =  -fPIC     -std=gnu++14 -I/uufs/chpc.utah.edu/sys/installdir/ffmpeg/4.0.2/include
+
+CMakeFiles/FluoRender.dir/link.txt
+- need to add -lz (for bzip2) and FFMPEG at the end of the link line:
+
+-L/uufs/chpc.utah.edu/sys/installdir/ffmpeg/4.0.2/lib -lavformat -lavcodec -llzma -lz -lswscale -lswresample -lavutil -lm
+
+$ make
+$ make install
+

--- a/fluorender/FluoRender/FLIVR/Framebuffer.h
+++ b/fluorender/FluoRender/FLIVR/Framebuffer.h
@@ -30,6 +30,9 @@
 
 #include <string>
 #include <vector>
+#ifdef __linux__
+  #include <algorithm>
+#endif
 
 namespace FLIVR
 {

--- a/fluorender/FluoRender/FLIVR/KernelProgram.cpp
+++ b/fluorender/FluoRender/FLIVR/KernelProgram.cpp
@@ -64,11 +64,17 @@ namespace FLIVR
 			size_t *param_value_size_ret) = NULL;
 		myclGetGLContextInfoKHR = (P1)clGetExtensionFunctionAddress("clGetGLContextInfoKHR");
 #endif
-#ifdef _DARWIN
+#if defined(_DARWIN) || defined(__linux__)
 		cl_context_properties properties[] =
 		{
+                #if defined(_DARWIN) 
 			CL_CONTEXT_PROPERTY_USE_CGL_SHAREGROUP_APPLE,
 			(cl_context_properties)CGLGetShareGroup(CGLGetCurrentContext()),
+                #elif defined(__linux__)
+                       // https://www.codeproject.com/Articles/685281/OpenGL-OpenCL-Interoperability-A-Case-Study-Using
+                       CL_GL_CONTEXT_KHR , (cl_context_properties) glXGetCurrentContext() ,
+                       CL_GLX_DISPLAY_KHR , (cl_context_properties) glXGetCurrentDisplay() ,
+                #endif
 			CL_CONTEXT_PLATFORM, (cl_context_properties)0,
 			0
 		};
@@ -130,7 +136,7 @@ namespace FLIVR
 				delete[] devices;
 			}
 #endif
-#ifdef _DARWIN
+#if defined(_DARWIN) || defined(__linux__)
 			properties[3] = (cl_context_properties)(platforms[i]);
 			if (device_id_ >= 0 && device_id_ < device_num)
 				device_ = devices[device_id_];

--- a/fluorender/FluoRender/FLIVR/KernelProgram.h
+++ b/fluorender/FluoRender/FLIVR/KernelProgram.h
@@ -2,6 +2,9 @@
 #define KernelProgram_h
 
 #include <GL/glew.h>
+#if defined(__linux__)
+#include <GL/glx.h>
+#endif
 #if defined(_WIN32) || defined(__linux__)
 #include <CL/cl.h>
 #include <CL/cl_gl.h>

--- a/fluorender/FluoRender/JVMInitializer.h
+++ b/fluorender/FluoRender/JVMInitializer.h
@@ -31,6 +31,10 @@ DEALINGS IN THE SOFTWARE.
 #include "../compatibility.h"
 //#include "VRenderFrame.h"
 
+#ifdef __linux__
+  #include <dlfcn.h>
+#endif
+
 #ifndef _JVMINITIALIZER_H_
 #define _JVMINITIALIZER_H_
 

--- a/fluorender/FluoRender/Scenegraph/Node.h
+++ b/fluorender/FluoRender/Scenegraph/Node.h
@@ -32,6 +32,9 @@ DEALINGS IN THE SOFTWARE.
 #include <vector>
 #include <Flobject/CopyOp.h>
 #include <Flobject/Object.h>
+#if defined(__linux__)
+#include <algorithm>
+#endif
 
 namespace FL
 {

--- a/fluorender/FluoRender/Video/QVideoEncoder.h
+++ b/fluorender/FluoRender/Video/QVideoEncoder.h
@@ -30,6 +30,13 @@ extern "C" {
 #include <libswresample/swresample.h>
 	}
 }
+
+// MC hack to add two missing defines from older FFMPEG versions
+#ifdef __linux__
+  #define CODEC_FLAG_GLOBAL_HEADER   0x00400000
+  #define AVFMT_RAWPICTURE   0x0020
+#endif
+
 #define STREAM_PIX_FMT    ffmpeg::AV_PIX_FMT_YUV420P /* default pix_fmt */
 #define SCALE_FLAGS SWS_BICUBIC
 


### PR DESCRIPTION
Hi Yong,

this is my pull request for building on Linux. See new file build_linux.txt in the root directory.

We built this on our CentOS 7.4 system with more-less vanilla libraries (just base and EPEL channels), custom built gcc 5.4.0 and boost, and subsequently custom built wxWidgets and ffmpeg (their built is described in build_linux.txt).

I admit that modifying the OpenCL contexts is a hack since I don't have any experience with that, so, I would be questioning if this works. That may be the reason for the segfaults that I am getting in the /lib64/libnvidia-opencl.so.1 when trying to launch the built executable. Some checking on this would be useful which I think you'd be better at since at least you understand the OpenCL contexts from the Windows and Mac perspective. If what I did looks OK, then we'd probably want to run debugger on the binary to get a better idea about the segfault. I'd be happy to help with that utilizing access to our system, sharing my CMake configure/build options and using our DDT debugger license.

Thanks.